### PR TITLE
Update; Add read parsing options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get install -y xclip xsel xvfb --no-install-recommends
-          curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh -s v0.25.0
+          curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh -s v1.0.5
 
       - name: Install Deno (Mac)
         if: startsWith(matrix.os, 'macOS')
         run: |
-          curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh -s v0.25.0
+          curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh -s v1.0.5
   
       - name: Install Deno (Windows)
         if: startsWith(matrix.os, 'windows')
@@ -50,4 +50,4 @@ jobs:
       - name: Test (Mac and Windows)
         if: matrix.kind == 'test' && !startsWith(matrix.os, 'ubuntu')
         run: |
-          deno test --allow-run --allow-net test.ts
+          deno test --allow-run test.ts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": true
+}

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ Deno clipboard library
 
 [![Build Status][actions-img]][actions-url]<br>(CI tests on Linux, Mac, Windows)
 
+> On Linux, `xsel` or `xclip` must be installed and in your `PATH`.
+
 Usage
 -
 
 ```ts
-import { clipboard } from 'https://deno.land/x/clipboard/mod.ts';
+import * as clipboard from 'https://deno.land/x/clipboard/mod.ts';
 
 await clipboard.writeText('some text');
 
@@ -33,18 +35,24 @@ then hopefully this will be obsolete. See the relevant issue:
 
 - [denoland/deno#3450 Support of Clipboard API without `--deno-run`](https://github.com/denoland/deno/issues/3450)
 
-Notes
+Options
 -
-On Linux it requires `xsel` to be installed (probably installed by default).
+The clipboard on Windows always adds a trailing newline if there was none,
+which makes single line strings end with a newline. Newlines in the clipboard are sometimes
+problematic (like automatically starting commands when pasted into the terminal), so this module trims leading and trailing whitespace by default. It also converts CRLF (Windows) newlines to LF (Unix) newlines by default when reading the clipboard.
 
-The clipboard on Windows always adds a trailing newline if there was none
-which makes single line strings end with a newline and this module removes the
-trailing newline on Windows, but it means that if it was there originally then it will still
-be removed - to preserve single-line strings being single-line, but maybe this is not the right
-way to do it. The other option would be to preserve the trailing newline but also to get one
-if it wasn't there. Currently I chose to remove it because newlines in the clipboard sometimes
-are problematic (like automatically starting commands when pasted into the terminal).
-TODO: think about it.
+Both of these options can be disabled independently:
+
+```ts
+import * as clipboard from 'https://deno.land/x/clipboard/mod.ts';
+
+const options: clipboard.ReadTextOptions = {
+  trim: false, // don't trim leading or trailing whitespace
+  unixNewlines: false, // don't convert CRLF to LF
+};
+
+const clipboardText = await clipboard.readText(options);
+```
 
 Issues
 -
@@ -59,6 +67,10 @@ Author
 [![Follow on Twitter][twitter-follow-img]][twitter-follow-url]
 <br/>
 [![Follow on Stack Exchange][stackexchange-img]][stackoverflow-url]
+
+Contributors
+-
+- [**Jesse Jackson**](https://github.com/jsejcksn)
 
 License
 -

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options
 -
 The clipboard on Windows always adds a trailing newline if there was none,
 which makes single line strings end with a newline. Newlines in the clipboard are sometimes
-problematic (like automatically starting commands when pasted into the terminal), so this module trims leading and trailing whitespace by default. It also converts CRLF (Windows) newlines to LF (Unix) newlines by default when reading the clipboard.
+problematic (like automatically starting commands when pasted into the terminal), so this module trims trailing newlines by default. It also converts CRLF (Windows) newlines to LF (Unix) newlines by default when reading the clipboard.
 
 Both of these options can be disabled independently:
 
@@ -47,7 +47,7 @@ Both of these options can be disabled independently:
 import * as clipboard from 'https://deno.land/x/clipboard/mod.ts';
 
 const options: clipboard.ReadTextOptions = {
-  trim: false, // don't trim leading or trailing whitespace
+  trimFinalNewlines: false, // don't trim trailing newlines
   unixNewlines: false, // don't convert CRLF to LF
 };
 

--- a/example1.ts
+++ b/example1.ts
@@ -1,7 +1,7 @@
-import { clipboard } from './mod.ts';
+import * as clipboard from './mod.ts';
 
-const x = 'abcaaa';
+const text = 'abcaaa';
 
-await clipboard.writeText(x);
+await clipboard.writeText(text);
 
 console.log(await clipboard.readText());

--- a/example2.ts
+++ b/example2.ts
@@ -1,3 +1,3 @@
-import { clipboard } from './mod.ts';
+import * as clipboard from './mod.ts';
 
 console.log(await clipboard.readText());

--- a/example3.ts
+++ b/example3.ts
@@ -1,4 +1,4 @@
-import { clipboard } from './mod.ts';
+import * as clipboard from './mod.ts';
 
 await clipboard.writeText('some text');
 

--- a/mod.ts
+++ b/mod.ts
@@ -43,12 +43,7 @@ const shared = {
     cmd: string[],
     {trim = true, unixNewlines = true}: ReadTextOptions = {},
   ): Promise<string> {
-    const runOpts: Deno.RunOptions = {
-      cmd,
-      stdout: 'piped',
-    };
-
-    const p = Deno.run(runOpts);
+    const p = Deno.run({cmd, stdout: 'piped'});
 
     const {success} = await p.status();
     if (!success) throw new Error(errMsg.genericRead);
@@ -64,12 +59,7 @@ const shared = {
   },
 
   async writeText (cmd: string[], data: string): Promise<void> {
-    const runOpts: Deno.RunOptions = {
-      cmd,
-      stdin: 'piped',
-    };
-
-    const p = Deno.run(runOpts);
+    const p = Deno.run({cmd, stdin: 'piped'});
 
     if (!p.stdin) throw new Error(errMsg.genericWrite);
     await p.stdin.write(encoder.encode(data));
@@ -131,12 +121,7 @@ const windows: TextClipboard = {
 };
 
 const getProcessOutput = async (cmd: string[]): Promise<string> => {
-  const runOpts: Deno.RunOptions = {
-    cmd,
-    stdout: 'piped',
-  };
-
-  const p = Deno.run(runOpts);
+  const p = Deno.run({cmd, stdout: 'piped'});
   const output = decoder.decode(await p.output());
   p.close();
   return output.trim();

--- a/mod.ts
+++ b/mod.ts
@@ -118,19 +118,8 @@ const windows: TextClipboard = {
   },
 
   async writeText (data: string): Promise<void> {
-    const cmd: string[] = ['powershell', '-NoProfile', '-Command', 'Set-Clipboard -Value "$env:DENO_CLIPBOARD_TEXT"'];
-
-    const runOpts: Deno.RunOptions = {
-      cmd,
-      env: {DENO_CLIPBOARD_TEXT: data},
-    };
-
-    const p = Deno.run(runOpts);
-
-    const {success} = await p.status();
-    if (!success) throw new Error(errMsg.genericWrite);
-
-    p.close();
+    const cmd: string[] = ['powershell', '-NoProfile', '-Command', '$input|Set-Clipboard'];
+    return shared.writeText(cmd, data);
   }
 };
 

--- a/mod.ts
+++ b/mod.ts
@@ -21,6 +21,13 @@ const errMsg = {
   osUnsupported: 'Unsupported operating system',
 };
 
+/**
+ * Options to change the parsing behavior when reading the clipboard text
+ * 
+ * `trim` — (optional) Trim leading and trailing whitespace. Default is `true`.
+ * 
+ * `unixNewlines` — (optional) Convert all CRLF newlines to LF newlines. Default is `true`.
+ */
 export type ReadTextOptions = {
   trim?: boolean;
   unixNewlines?: boolean;
@@ -169,5 +176,12 @@ const {build: {os}} = Deno;
 if (os === 'linux') config.linuxBinary = await resolveLinuxBinary();
 else if (!clipboards[os]) throw new Error(errMsg.osUnsupported);
 
-export const readText = clipboards[os].readText;
-export const writeText = clipboards[os].writeText;
+/**
+ * Reads the clipboard and returns a string containing the text contents. Requires the `--allow-run` flag.
+ */
+export const readText: (readTextOptions?: ReadTextOptions) => Promise<string> = clipboards[os].readText;
+
+/**
+ * Writes a string to the clipboard. Requires the `--allow-run` flag.
+ */
+export const writeText: (data: string) => Promise<void> = clipboards[os].writeText;

--- a/mod.ts
+++ b/mod.ts
@@ -167,7 +167,9 @@ const resolveLinuxBinary = async (): Promise<LinuxBinary> => {
   throw new Error(errMsg.noClipboardUtility);
 };
 
-const clipboards = {
+type Clipboards = {[key in typeof Deno.build.os]: TextClipboard};
+
+const clipboards: Clipboards = {
   darwin,
   linux,
   windows,

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-deno test --allow-run --allow-net test.ts
+deno test --allow-run test.ts

--- a/test.ts
+++ b/test.ts
@@ -3,11 +3,11 @@ import {readText, writeText} from './mod.ts';
 
 type Test = [string, () => void | Promise<void>];
 
+let originalClipboard = '';
+
 const tests: Test[] = [
-  ['reads/writes without throwing', async () => {
-    const input = 'hello world';
-    await writeText(input);
-    await readText();
+  ['reads without throwing', async () => {
+    originalClipboard = await readText({unixNewlines: false});
   }],
   ['single line data', async () => {
     const input = 'single line data';
@@ -39,7 +39,7 @@ const tests: Test[] = [
     const output = await readText();
     assertEquals(output.replace(/\n+$/u, ''), input.replace(/\n+$/u, ''));
   }],
-  ['option: trim', async () => {
+  ['option: trimFinalNewlines', async () => {
     const input = 'hello world\n\n';
     const inputTrimmed = 'hello world';
     await writeText(input);
@@ -60,6 +60,9 @@ const tests: Test[] = [
     assertEquals(inputCRLF, output);
     assertEquals(inputLF, outputUnix);
     assertEquals(inputLF, outputDefault);
+  }],
+  ['writes without throwing', async () => {
+    await writeText(originalClipboard);
   }],
 ];
 

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-import {assert, assertEquals} from 'https://deno.land/std@0.56.0/testing/asserts.ts';
+import {assert, assertEquals} from 'https://deno.land/std@0.59.0/testing/asserts.ts';
 import {readText, writeText} from './mod.ts';
 
 type Test = [string, () => void | Promise<void>];
@@ -13,38 +13,38 @@ const tests: Test[] = [
     const input = 'single line data';
     await writeText(input);
     const output = await readText();
-    assertEquals(output.replace(/\n+$/, ''), input.replace(/\n+$/, ''));
+    assertEquals(output.replace(/\n+$/u, ''), input.replace(/\n+$/u, ''));
   }],
   ['multi line data', async () => {
     const input = 'multi\nline\ndata';
     await writeText(input);
     const output = await readText();
-    assertEquals(output.replace(/\n+$/, ''), input.replace(/\n+$/, ''));
+    assertEquals(output.replace(/\n+$/u, ''), input.replace(/\n+$/u, ''));
   }],
   ['multi line data dangling newlines', async () => {
     const input = '\n\n\nmulti\n\n\n\n\n\nline\ndata\n\n\n\n\n';
     await writeText(input);
-    const output = await readText({trim: false});
-    assertEquals(output.replace(/\n+$/, ''), input.replace(/\n+$/, ''));
+    const output = await readText({trimFinalNewlines: false});
+    assertEquals(output.replace(/\n+$/u, ''), input.replace(/\n+$/u, ''));
   }],
   ['data with special characters', async () => {
     const input = '`~!@#$%^&*()_+-=[]{};\':",./<>?\t\n';
     await writeText(input);
-    const output = await readText({trim: false});
-    assertEquals(output.replace(/\n+$/, ''), input.replace(/\n+$/, ''));
+    const output = await readText({trimFinalNewlines: false});
+    assertEquals(output.replace(/\n+$/u, ''), input.replace(/\n+$/u, ''));
   }],
   ['data with unicode characters', async () => {
     const input = 'Rafał';
     await writeText(input);
     const output = await readText();
-    assertEquals(output.replace(/\n+$/, ''), input.replace(/\n+$/, ''));
+    assertEquals(output.replace(/\n+$/u, ''), input.replace(/\n+$/u, ''));
   }],
   ['option: trim', async () => {
     const input = 'hello world\n\n';
     const inputTrimmed = 'hello world';
     await writeText(input);
-    const output = await readText({trim: false});
-    const outputTrimmed = await readText({trim: true});
+    const output = await readText({trimFinalNewlines: false});
+    const outputTrimmed = await readText({trimFinalNewlines: true});
     const outputDefault = await readText();
     assert(output !== inputTrimmed && output.trim() === inputTrimmed);
     assertEquals(inputTrimmed, outputTrimmed);
@@ -63,4 +63,4 @@ const tests: Test[] = [
   }],
 ];
 
-for (const [name, fn] of tests) Deno.test({name, fn});
+for (const [name, fn] of tests) Deno.test({fn, name});


### PR DESCRIPTION
This PR resolves #3 and resolves #4.

## Notes

It is technically a re-write (I wrote much of the code before discovering your repo, but found it when I encountered a Powershell issue). Instead of publishing a new Deno module, I have reviewed your code, and restructured the code in this PR to more closely align to the existing structure.

The PR focuses on addressing a few core issues:

- Updating the code to work with Deno's current API
- Adding read parsing options for newline control characters and trailing newlines
- Supporting both `xsel` and `xclip` on Linux (in that order)
- Adding support for Linux on WSL

An important note: the export format is changed, so the major version should be increased if published.

Previously, the methods could only be accessed on the `clipboard` export:

```ts
import {clipboard} from 'https://deno.land/x/clipboard/mod.ts';

await clipboard.writeText('hello world');
await clipboard.readText();
```

Now, there is more flexibility for importing.

Like this:
```ts
import * as clipboard from 'https://deno.land/x/clipboard/mod.ts';

await clipboard.writeText('hello world');
await clipboard.readText();
```

Or like this:
```ts
import {readText, writeText} from 'https://deno.land/x/clipboard/mod.ts';

await writeText('hello world');
await readText();
```

Thanks for writing this module. Please review and let me know your thoughts. Cheers!